### PR TITLE
Gulp task 'js:dev' was missing.

### DIFF
--- a/generators/app/templates/helpers/_gulp/_scripts.require.js.ejs
+++ b/generators/app/templates/helpers/_gulp/_scripts.require.js.ejs
@@ -4,7 +4,7 @@ var gulp = require('gulp'); <% if (gulpModules && gulpModules.indexOf('gulp-ugli
 var uglify = require('gulp-uglify');<% } %> <% if (gulpModules && gulpModules.indexOf('gulp-requirejs-optimize') != -1) { %>
 var requirejsOptimize = require('gulp-requirejs-optimize');<% } %>
 
-gulp.task('js', function () {<% if (gulpModules && gulpModules.indexOf('gulp-requirejs-optimize') != -1 || gulpModules && gulpModules.indexOf('browserify') != -1) { %>
+gulp.task('js:dev', function () {<% if (gulpModules && gulpModules.indexOf('gulp-requirejs-optimize') != -1 || gulpModules && gulpModules.indexOf('browserify') != -1) { %>
 	return gulp.src(path.src + '/js/main.js')<% } else { %>return gulp.src(path.src + '/js/**/*.js')<% } %><% if (gulpModules && gulpModules.indexOf('gulp-requirejs-optimize') != -1) { %>
 		.pipe(requirejsOptimize({
 			baseUrl: path.src + '/js',


### PR DESCRIPTION
'js:dev' is used in Gulpfile, but it was defined as 'js' in helper.
Both were 'scripts' before 3cc5df0e4fecab539c20d316ea72ad88216fbb49.