### PR TITLE
Fixed small quotation mark issue

### DIFF
--- a/generators/app/templates/resources/templating/partials/blocks/b-nav.hbs
+++ b/generators/app/templates/resources/templating/partials/blocks/b-nav.hbs
@@ -7,7 +7,7 @@ block: nav
 	<ul class="nav__list">
 		{{#withSort pages 'data.sortOrder'}}
 			<li class="nav__list-item">
-				<a href="{{autolink}}" class="nav__list-item-link{{#is ../page.dest this.dest}} is-active"{{/is}}>{{data.menuLink}}</a>
+				<a href="{{autolink}}" class="nav__list-item-link{{#is ../page.dest this.dest}} is-active{{/is}}">{{data.menuLink}}</a>
 			</li>
 		{{/withSort}}
 	</ul>


### PR DESCRIPTION
Moved closing quotation mark out of the handlebars helper to ensure valid html if "#is"-check is false.