### PR TITLE
Added missing dependency in gruntfile.js

### DIFF
--- a/generators/app/templates/Gruntfile.js.ejs
+++ b/generators/app/templates/Gruntfile.js.ejs
@@ -23,7 +23,7 @@ var config = require('./helpers/config');
 module.exports = function(grunt) {
 	
 	// load only used tasks and add fallbacks for those which cannot be find
-	require('jit-grunt')(grunt, {<% if (gruntModules && gruntModules.length && (gruntModules.indexOf('grunt-grunticon') != -1 || gruntModules.indexOf('grunt-dr-svg-sprites') != -1)) { %>
+	require('jit-grunt')(grunt, {<% if (gruntModules && gruntModules.length && (gruntModules.indexOf('grunt-grunticon') != -1 || gruntModules.indexOf('grunt-dr-svg-sprites') != -1 || gruntModules.indexOf('grunt-contrib-handlebars') != -1)) { %>
 		'replace': 'grunt-text-replace',<% } %>
 		'express': 'grunt-express-server'
 	});


### PR DESCRIPTION
The static mapping for the grunt-text-replace plugin was missing, if only grunt-contrib-handlebars is used.